### PR TITLE
install coreutils to use date command normally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:alpine
 RUN apk add --no-cache supervisor
+RUN apk add --update coreutils && rm -rf /var/cache/apk/*
 ADD supervisord.conf /etc/supervisord.conf
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]


### PR DESCRIPTION
小雪的定时脚本使用了date -d参数来定义日期，只有安装coreutils以后才能正常使用